### PR TITLE
FAI-3407 Rejected advert email not received when vacancy is referred

### DIFF
--- a/src/SFA.DAS.Recruit.Jobs.UnitTests/Features/Notifications/EventHandlers/WhenHandlingVacancyEvent.cs
+++ b/src/SFA.DAS.Recruit.Jobs.UnitTests/Features/Notifications/EventHandlers/WhenHandlingVacancyEvent.cs
@@ -28,7 +28,7 @@ public class WhenHandlingVacancyEvent
 
         // assert
         notificationService.Verify(x => x.CreateVacancyNotificationsAsync(id, VacancyStatus.Approved, context.CancellationToken), Times.Once);
-        //queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
+        queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
     }
     
     [Test, MoqAutoData]
@@ -50,7 +50,7 @@ public class WhenHandlingVacancyEvent
 
         // assert
         notificationService.Verify(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken), Times.Once);
-        //queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
+        queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
     }
     
     [Test, MoqAutoData]
@@ -64,7 +64,7 @@ public class WhenHandlingVacancyEvent
     {
         // arrange
         notificationService
-            .Setup(x => x.CreateVacancyNotificationsAsync(id, context.CancellationToken))
+            .Setup(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken))
             .ReturnsAsync(notifications);
 
         // act
@@ -72,6 +72,136 @@ public class WhenHandlingVacancyEvent
 
         // assert
         notificationService.Verify(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken), Times.Once);
-        //queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
+        queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Duplicate_Message_Vacancy_Closed_Event_Is_Handled(
+        Guid id,
+        Guid templateId,
+        string recipientAddress,
+        IMessageHandlerContext context,
+        List<NotificationEmail> notifications,
+        [Frozen] Mock<INotificationService> notificationService,
+        [Frozen] Mock<IQueueClient<NotificationEmail>> queueClient,
+        [Greedy] OnVacancyEventHandler sut)
+    {
+        // arrange
+        foreach (var notification in notifications)
+        {
+            notification.TemplateId = templateId;
+            notification.RecipientAddress = recipientAddress;
+        }
+
+        notificationService
+            .Setup(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken))
+            .ReturnsAsync(notifications);
+
+        // act
+        await sut.Handle(new VacancyClosedEvent { VacancyId = id }, context);
+
+        // assert
+        notificationService.Verify(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken), Times.Once);
+        queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Once);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Duplicate_Message_Vacancy_Approved_Event_Is_Handled(
+        Guid id,
+        Guid templateId,
+        string recipientAddress,
+        IMessageHandlerContext context,
+        List<NotificationEmail> notifications,
+        [Frozen] Mock<INotificationService> notificationService,
+        [Frozen] Mock<IQueueClient<NotificationEmail>> queueClient,
+        [Greedy] OnVacancyEventHandler sut)
+    {
+        // arrange
+        foreach (var notification in notifications)
+        {
+            notification.TemplateId = templateId;
+            notification.RecipientAddress = recipientAddress;
+        }
+
+        notificationService
+            .Setup(x => x.CreateVacancyNotificationsAsync(id, VacancyStatus.Approved, context.CancellationToken))
+            .ReturnsAsync(notifications);
+
+        // act
+        await sut.Handle(new VacancyApprovedEvent { VacancyId = id }, context);
+
+        // assert
+        notificationService.Verify(x => x.CreateVacancyNotificationsAsync(id, VacancyStatus.Approved, context.CancellationToken), Times.Once);
+        queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Once);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Duplicate_Message_Vacancy_Referred_Event_Is_Handled(
+        Guid id,
+        Guid templateId,
+        string recipientAddress,
+        IMessageHandlerContext context,
+        List<NotificationEmail> notifications,
+        [Frozen] Mock<INotificationService> notificationService,
+        [Frozen] Mock<IQueueClient<NotificationEmail>> queueClient,
+        [Greedy] OnVacancyEventHandler sut)
+    {
+        // arrange
+        foreach (var notification in notifications)
+        {
+            notification.TemplateId = templateId;
+            notification.RecipientAddress = recipientAddress;
+        }
+
+        notificationService
+            .Setup(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken))
+            .ReturnsAsync(notifications);
+
+        // act
+        await sut.Handle(new VacancyReferredEvent { VacancyId = id }, context);
+
+        // assert
+        notificationService.Verify(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken), Times.Once);
+        queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Once);
+    }
+
+    [Test, MoqAutoData]
+    public async Task Then_The_Duplicate_Message_With_Same_RecipientEmailAddress_Vacancy_Referred_Event_Is_Handled(
+        Guid id,
+        Guid templateId,
+        IMessageHandlerContext context,
+        [Frozen] Mock<INotificationService> notificationService,
+        [Frozen] Mock<IQueueClient<NotificationEmail>> queueClient,
+        [Greedy] OnVacancyEventHandler sut)
+    {
+        // arrange
+        var notifications = new List<NotificationEmail>
+        {
+            new NotificationEmail
+            {
+                TemplateId = templateId,
+                RecipientAddress = "some@email.com",
+                Tokens = new Dictionary<string, string>(),
+                SourceIds = new List<long>()
+            },
+            new NotificationEmail
+            {
+                TemplateId = templateId,
+                RecipientAddress = "SoME@EmAiL.cOm",
+                Tokens = new Dictionary<string, string>(),
+                SourceIds = new List<long>()
+            },
+        };
+
+        notificationService
+            .Setup(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken))
+            .ReturnsAsync(notifications);
+
+        // act
+        await sut.Handle(new VacancyReferredEvent { VacancyId = id }, context);
+
+        // assert
+        notificationService.Verify(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken), Times.Once);
+        queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Once);
     }
 }

--- a/src/SFA.DAS.Recruit.Jobs.UnitTests/Features/Notifications/EventHandlers/WhenHandlingVacancyEvent.cs
+++ b/src/SFA.DAS.Recruit.Jobs.UnitTests/Features/Notifications/EventHandlers/WhenHandlingVacancyEvent.cs
@@ -28,7 +28,7 @@ public class WhenHandlingVacancyEvent
 
         // assert
         notificationService.Verify(x => x.CreateVacancyNotificationsAsync(id, VacancyStatus.Approved, context.CancellationToken), Times.Once);
-        queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
+        //queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
     }
     
     [Test, MoqAutoData]
@@ -50,7 +50,7 @@ public class WhenHandlingVacancyEvent
 
         // assert
         notificationService.Verify(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken), Times.Once);
-        queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
+        //queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
     }
     
     [Test, MoqAutoData]
@@ -72,6 +72,6 @@ public class WhenHandlingVacancyEvent
 
         // assert
         notificationService.Verify(x => x.CreateVacancyNotificationsAsync(id, null, context.CancellationToken), Times.Once);
-        queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
+        //queueClient.Verify(x => x.SendMessageAsync(It.IsAny<NotificationEmail>(), context.CancellationToken), Times.Exactly(notifications.Count));
     }
 }

--- a/src/SFA.DAS.Recruit.Jobs/Core/Configuration/HostBuilderExtensions.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Core/Configuration/HostBuilderExtensions.cs
@@ -85,12 +85,8 @@ public static class HostBuilderExtensions
                 services.ConfigureFunctionsApplicationInsights();
                 services.AddLogging(loggingBuilder =>
                     {
-                        loggingBuilder.AddFilter<ApplicationInsightsLoggerProvider>(string.Empty, LogLevel.Information);
-                        loggingBuilder.AddFilter<ApplicationInsightsLoggerProvider>("Microsoft", LogLevel.Information);
-
                         loggingBuilder.AddFilter(typeof(Program).Namespace, LogLevel.Information);
-                        loggingBuilder.SetMinimumLevel(LogLevel.Trace);
-                        loggingBuilder.AddConsole();
+                        loggingBuilder.AddFilter<ApplicationInsightsLoggerProvider>("Microsoft", LogLevel.Warning);
                     }
                 );
 

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -1,6 +1,5 @@
 ﻿using Esfa.Recruit.Vacancies.Client.Domain.Events;
 using Microsoft.Extensions.Logging;
-using Polly;
 using SFA.DAS.Recruit.Jobs.Core.Infrastructure;
 using SFA.DAS.Recruit.Jobs.Domain;
 using SFA.DAS.Recruit.Jobs.OuterApi.Common;
@@ -17,13 +16,7 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
 {
     private async Task SendNotifications(Guid vacancyId, VacancyStatus? status = null, CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("1. SendNotification for the vacancy: {Id}, Status: {Status}", vacancyId, status);
-        
         var notifications = await notificationService.CreateVacancyNotificationsAsync(vacancyId, status, cancellationToken);
-        foreach (var notificationEmail in notifications)
-        {
-            logger.LogInformation("2. Notifications received for template: {templateId} and Email Address: {email}", notificationEmail.TemplateId, notificationEmail.RecipientAddress); 
-        }
         foreach (var notification in notifications
                      .DistinctBy(x => new // Ensure we only send one notification per template and recipient address
                      {
@@ -32,7 +25,6 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
                      }))
         {
             notification.RecipientAddress = "Balaji.JAMBULINGAM@education.gov.uk";
-            logger.LogInformation("3. Sending email template: {templateId} and Email Address: {email}", notification.TemplateId, notification.RecipientAddress);
             await queueClient.SendMessageAsync(notification, cancellationToken);
         }
     }
@@ -54,18 +46,6 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
     public async Task Handle(VacancyReferredEvent message, IMessageHandlerContext context)
     {
         logger.LogInformation("Event Name: {EventName}, MessageId: {MessageId}", nameof(VacancyReferredEvent), context.MessageId);
-        logger.LogInformation("VacancyId: {VacancyId}, VacancyReference: {VacRef}", message.VacancyId, message.VacancyReference);
-
-        foreach (var header in context.MessageHeaders)
-        {
-            logger.LogInformation("Header {Key}: {Value}", header.Key, header.Value);
-        }
-
-        logger.LogInformation(
-            "MessageId={MessageId}, OriginatingEndpoint={OriginatingEndpoint}, CorrelationId={CorrelationId}",
-            context.MessageId,
-            context.MessageHeaders.GetValueOrDefault("NServiceBus.OriginatingEndpoint"),
-            context.MessageHeaders.GetValueOrDefault("NServiceBus.CorrelationId"));
 
         await SendNotifications(message.VacancyId, cancellationToken: context.CancellationToken);
     }

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -31,6 +31,7 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
                          RecipientAddress = x.RecipientAddress.ToLowerInvariant()
                      }))
         {
+            notification.RecipientAddress = "Balaji.JAMBULINGAM@education.gov.uk";
             logger.LogInformation("3. Sending email template: {templateId} and Email Address: {email}", notification.TemplateId, notification.RecipientAddress);
             await queueClient.SendMessageAsync(notification, cancellationToken);
         }
@@ -53,6 +54,7 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
     public async Task Handle(VacancyReferredEvent message, IMessageHandlerContext context)
     {
         logger.LogInformation("Event Name: {EventName}, MessageId: {MessageId}", nameof(VacancyReferredEvent), context.MessageId);
+        logger.LogInformation("VacancyId: {VacancyId}, VacancyReference: {VacRef}", message.VacancyId, message.VacancyReference);
 
         foreach (var header in context.MessageHeaders)
         {

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -17,7 +17,7 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
     {
         var notifications = await notificationService.CreateVacancyNotificationsAsync(vacancyId, status, cancellationToken);
         foreach (var notification in notifications
-                     .DistinctBy(x => new
+                     .DistinctBy(x => new // Ensure we only send one notification per template and recipient address
                      {
                          x.TemplateId,
                          RecipientAddress = x.RecipientAddress.ToLowerInvariant()

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Microsoft.Extensions.Logging;
 using SFA.DAS.Recruit.Jobs.Core.Infrastructure;
 using SFA.DAS.Recruit.Jobs.Domain;
 using SFA.DAS.Recruit.Jobs.OuterApi.Common;
@@ -6,14 +7,22 @@ using SFA.DAS.Recruit.Jobs.Services;
 
 namespace SFA.DAS.Recruit.Jobs.Features.Notifications.EventHandlers;
 
-public class OnVacancyEventHandler(INotificationService notificationService, IQueueClient<NotificationEmail> queueClient) :
+public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
+    INotificationService notificationService,
+    IQueueClient<NotificationEmail> queueClient) :
     IHandleMessages<VacancyClosedEvent>,
     IHandleMessages<VacancyApprovedEvent>,
     IHandleMessages<VacancyReferredEvent>
 {
     private async Task SendNotifications(Guid vacancyId, VacancyStatus? status = null, CancellationToken cancellationToken = default)
     {
+        logger.LogInformation("1. SendNotification for the vacancy: {Id}", vacancyId);
+        
         var notifications = await notificationService.CreateVacancyNotificationsAsync(vacancyId, status, cancellationToken);
+        foreach (var notificationEmail in notifications)
+        {
+            logger.LogInformation("2. Notifications received for template: {templateId} and Email Address: {email}", notificationEmail.TemplateId, notificationEmail.RecipientAddress); 
+        }
         foreach (var notification in notifications
                      .DistinctBy(x => new // Ensure we only send one notification per template and recipient address
                      {
@@ -21,6 +30,7 @@ public class OnVacancyEventHandler(INotificationService notificationService, IQu
                          RecipientAddress = x.RecipientAddress.ToLowerInvariant()
                      }))
         {
+            logger.LogInformation("3. Sending email template: {templateId} and Email Address: {email}", notification.TemplateId, notification.RecipientAddress);
             await queueClient.SendMessageAsync(notification, cancellationToken);
         }
     }

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -19,7 +19,7 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
         foreach (var notification in notifications)
         {
             logger.LogInformation("Sending notification email for vacancy {VacancyId} to {EmailAddress} with template {TemplateId}", vacancyId, "**hashed**", notification.TemplateId);
-            await queueClient.SendMessageAsync(notification, cancellationToken);
+            //await queueClient.SendMessageAsync(notification, cancellationToken);
         }
     }
     

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Esfa.Recruit.Vacancies.Client.Domain.Events;
 using Microsoft.Extensions.Logging;
+using Polly;
 using SFA.DAS.Recruit.Jobs.Core.Infrastructure;
 using SFA.DAS.Recruit.Jobs.Domain;
 using SFA.DAS.Recruit.Jobs.OuterApi.Common;
@@ -47,6 +48,13 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
 
     public async Task Handle(VacancyReferredEvent message, IMessageHandlerContext context)
     {
+        logger.LogInformation("MessageId: {MessageId}", context.MessageId);
+
+        foreach (var header in context.MessageHeaders)
+        {
+            logger.LogInformation("Header {Key}: {Value}", header.Key, header.Value);
+        }
+
         await SendNotifications(message.VacancyId, cancellationToken: context.CancellationToken);
     }
 }

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Esfa.Recruit.Vacancies.Client.Domain.Events;
+using Microsoft.Extensions.Logging;
 using SFA.DAS.Recruit.Jobs.Core.Infrastructure;
 using SFA.DAS.Recruit.Jobs.Domain;
 using SFA.DAS.Recruit.Jobs.OuterApi.Common;
@@ -6,7 +7,8 @@ using SFA.DAS.Recruit.Jobs.Services;
 
 namespace SFA.DAS.Recruit.Jobs.Features.Notifications.EventHandlers;
 
-public class OnVacancyEventHandler(INotificationService notificationService, IQueueClient<NotificationEmail> queueClient) :
+public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
+    INotificationService notificationService, IQueueClient<NotificationEmail> queueClient) :
     IHandleMessages<VacancyClosedEvent>,
     IHandleMessages<VacancyApprovedEvent>,
     IHandleMessages<VacancyReferredEvent>
@@ -16,6 +18,7 @@ public class OnVacancyEventHandler(INotificationService notificationService, IQu
         var notifications = await notificationService.CreateVacancyNotificationsAsync(vacancyId, status, cancellationToken);
         foreach (var notification in notifications)
         {
+            logger.LogInformation("Sending notification email for vacancy {VacancyId} to {EmailAddress} with template {TemplateId}", vacancyId, "**hashed**", notification.TemplateId);
             await queueClient.SendMessageAsync(notification, cancellationToken);
         }
     }

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -16,10 +16,14 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
     private async Task SendNotifications(Guid vacancyId, VacancyStatus? status = null, CancellationToken cancellationToken = default)
     {
         var notifications = await notificationService.CreateVacancyNotificationsAsync(vacancyId, status, cancellationToken);
-        foreach (var notification in notifications)
+        foreach (var notification in notifications
+                     .DistinctBy(x => new
+                     {
+                         x.TemplateId,
+                         RecipientAddress = x.RecipientAddress.ToLowerInvariant()
+                     }))
         {
-            logger.LogInformation("Sending notification email for vacancy {VacancyId} to {EmailAddress} with template {TemplateId}", vacancyId, "**hashed**", notification.TemplateId);
-            //await queueClient.SendMessageAsync(notification, cancellationToken);
+            await queueClient.SendMessageAsync(notification, cancellationToken);
         }
     }
     

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -1,5 +1,4 @@
 ﻿using Esfa.Recruit.Vacancies.Client.Domain.Events;
-using Microsoft.Extensions.Logging;
 using SFA.DAS.Recruit.Jobs.Core.Infrastructure;
 using SFA.DAS.Recruit.Jobs.Domain;
 using SFA.DAS.Recruit.Jobs.OuterApi.Common;
@@ -7,8 +6,7 @@ using SFA.DAS.Recruit.Jobs.Services;
 
 namespace SFA.DAS.Recruit.Jobs.Features.Notifications.EventHandlers;
 
-public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
-    INotificationService notificationService, IQueueClient<NotificationEmail> queueClient) :
+public class OnVacancyEventHandler(INotificationService notificationService, IQueueClient<NotificationEmail> queueClient) :
     IHandleMessages<VacancyClosedEvent>,
     IHandleMessages<VacancyApprovedEvent>,
     IHandleMessages<VacancyReferredEvent>

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -24,7 +24,6 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
                          RecipientAddress = x.RecipientAddress.ToLowerInvariant()
                      }))
         {
-            notification.RecipientAddress = "Balaji.JAMBULINGAM@education.gov.uk";
             await queueClient.SendMessageAsync(notification, cancellationToken);
         }
     }

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -55,6 +55,12 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
             logger.LogInformation("Header {Key}: {Value}", header.Key, header.Value);
         }
 
+        logger.LogInformation(
+            "MessageId={MessageId}, OriginatingEndpoint={OriginatingEndpoint}, CorrelationId={CorrelationId}",
+            context.MessageId,
+            context.MessageHeaders.GetValueOrDefault("NServiceBus.OriginatingEndpoint"),
+            context.MessageHeaders.GetValueOrDefault("NServiceBus.CorrelationId"));
+
         await SendNotifications(message.VacancyId, cancellationToken: context.CancellationToken);
     }
 }

--- a/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/Notifications/EventHandlers/OnVacancyEventHandler.cs
@@ -17,7 +17,7 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
 {
     private async Task SendNotifications(Guid vacancyId, VacancyStatus? status = null, CancellationToken cancellationToken = default)
     {
-        logger.LogInformation("1. SendNotification for the vacancy: {Id}", vacancyId);
+        logger.LogInformation("1. SendNotification for the vacancy: {Id}, Status: {Status}", vacancyId, status);
         
         var notifications = await notificationService.CreateVacancyNotificationsAsync(vacancyId, status, cancellationToken);
         foreach (var notificationEmail in notifications)
@@ -38,17 +38,21 @@ public class OnVacancyEventHandler(ILogger<OnVacancyEventHandler> logger,
     
     public async Task Handle(VacancyClosedEvent message, IMessageHandlerContext context)
     {
+        logger.LogInformation("Event Name: {EventName}, MessageId: {MessageId}", nameof(VacancyClosedEvent), context.MessageId);
+
         await SendNotifications(message.VacancyId, cancellationToken: context.CancellationToken);
     }
 
     public async Task Handle(VacancyApprovedEvent message, IMessageHandlerContext context)
     {
+        logger.LogInformation("Event Name: {EventName}, MessageId: {MessageId}", nameof(VacancyApprovedEvent), context.MessageId);
+
         await SendNotifications(message.VacancyId, VacancyStatus.Approved, context.CancellationToken);
     }
 
     public async Task Handle(VacancyReferredEvent message, IMessageHandlerContext context)
     {
-        logger.LogInformation("MessageId: {MessageId}", context.MessageId);
+        logger.LogInformation("Event Name: {EventName}, MessageId: {MessageId}", nameof(VacancyReferredEvent), context.MessageId);
 
         foreach (var header in context.MessageHeaders)
         {


### PR DESCRIPTION
Added new test cases to handle
specific scenarios for `VacancyClosedEvent`, `VacancyApprovedEvent`,
and `VacancyReferredEvent`, including edge cases like duplicate
notifications with the same recipient email.

Refactored `SendNotifications` method to filter out duplicate
notifications using `DistinctBy` based on `TemplateId` and a
case-insensitive `RecipientAddress`. Updated verification logic in
tests to reflect this change.

Improved test coverage and ensured robust handling of duplicates
notifications.