### PR TITLE
FAI-3446 Difference in closing times of auto closing vacancies

### DIFF
--- a/src/SFA.DAS.Recruit.Jobs/Features/VacanciesToClose/Endpoints/CloseExpiredVacanciesTimerTrigger.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/VacanciesToClose/Endpoints/CloseExpiredVacanciesTimerTrigger.cs
@@ -11,7 +11,7 @@ public class CloseExpiredVacanciesTimerTrigger(ILogger<CloseExpiredVacanciesTime
 {
     private const string TriggerName = nameof(CloseExpiredVacanciesTimerTrigger);
     private static readonly TimeSpan ExecutionTimeout = TimeSpan.FromSeconds(240);
-    private const string DailySchedule = "0 0 0 * * *";
+    private const string DailySchedule = "0 0 1 * * *";
 
     // Timer set to run at 00:00 AM every day
     [Function(TriggerName)]

--- a/src/SFA.DAS.Recruit.Jobs/Features/VacanciesToClose/Handlers/CloseExpiredVacanciesHandler.cs
+++ b/src/SFA.DAS.Recruit.Jobs/Features/VacanciesToClose/Handlers/CloseExpiredVacanciesHandler.cs
@@ -17,7 +17,8 @@ public class CloseExpiredVacanciesHandler(ILogger<CloseExpiredVacanciesHandler> 
 
         try
         {
-            var pointInTime = DateTime.UtcNow;
+            // Use only the date part of the current UTC time to ensure we are checking for vacancies that expired before today
+            var pointInTime = DateTime.UtcNow.Date;
 
             // Fetch vacancies that are expired as of pointInTime
             var response = await jobsOuterClient.GetVacanciesToCloseAsync(pointInTime, cancellationToken);


### PR DESCRIPTION
Update vacancy close schedule and date handling

Changed timer trigger to run at 1 AM daily instead of midnight. Updated vacancy expiration logic to use only the current UTC date, ensuring only vacancies expired before today are closed.